### PR TITLE
增加 Java 实现的密码加密工具类

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
         </dependency>
+        <!-- AES 加密所需的 PKCS7Padding 的 Provider -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.67</version>
+        </dependency>
 
         <!--        <dependency>-->
 <!--            <groupId>org.springframework.security</groupId>-->

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,16 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.tess4j</groupId>
+            <artifactId>tess4j</artifactId>
+            <version>4.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>2.0.8</version>
+        </dependency>
 
         <!--        <dependency>-->
 <!--            <groupId>org.springframework.security</groupId>-->

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,10 @@
             <artifactId>bcprov-jdk15on</artifactId>
             <version>1.67</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
 
         <!--        <dependency>-->
 <!--            <groupId>org.springframework.security</groupId>-->

--- a/src/main/java/com/yilin/csuftspider/utils/PasswordUtil.java
+++ b/src/main/java/com/yilin/csuftspider/utils/PasswordUtil.java
@@ -1,0 +1,121 @@
+package com.yilin.csuftspider.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.*;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.util.Base64;
+import java.util.Random;
+
+/**
+ * <p>
+ *  教务处密码加密工具类
+ * </p>
+ *
+ * @author : Xbai-hang
+ * @since : 2022/10/11
+ */
+@Slf4j
+public class PasswordUtil {
+
+    static {
+        // Java 默认不支持 PKCS7Padding, 需要手动加包
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    /**
+     * 默认去掉了容易混淆的字符oOLl,9gq,Vv,Uu,I1
+     */
+    private static final String PADDING_CHARS = "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678";
+
+    /**
+     * 区块大小
+     */
+    private static final int BLOCK_SIZE = 16;
+
+    /**
+     * PKCS7Padding 填充字符
+     */
+    @Deprecated
+    private static final Byte[] FILL_BYTES = {0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15};
+
+    /**
+     * 密码加密工具类
+     * @param password 密码
+     * @param key key
+     * @return 加密后的密钥
+     */
+    public static String encrypt(String password, String key) {
+        return aesEncrypt(password, key);
+    }
+
+    /**
+     * AES 128 CBC 标准加密
+     * @param password 密码
+     * @param key AES 密钥
+     * @return 加密后的密钥
+     */
+    private static String aesEncrypt(@NotNull String password, @NotNull String key) {
+        if (StringUtils.isEmpty(password) || StringUtils.isEmpty(key)) {
+            throw new IllegalArgumentException("密码为空或 key 为空");
+        }
+        if (key.length() != BLOCK_SIZE) {
+            return null;
+        }
+        byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+        // 设置密钥规范为 AES
+        SecretKeySpec spec = new SecretKeySpec(keyBytes, "AES");
+        // 算法/模式/补码方式
+        Cipher cipher;
+        try {
+             cipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
+        } catch (NoSuchPaddingException | NoSuchAlgorithmException e) {
+            log.error("encrypt algorithm error");
+            e.printStackTrace();
+            return "";
+        }
+        IvParameterSpec iv = new IvParameterSpec(randomString(BLOCK_SIZE).getBytes(StandardCharsets.UTF_8));
+        byte[] encrypted;
+        try {
+            cipher.init(Cipher.ENCRYPT_MODE, spec, iv);
+            encrypted = cipher.doFinal(getPaddingPassword(password).getBytes(StandardCharsets.UTF_8));
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException | IllegalBlockSizeException | BadPaddingException e) {
+            log.error("password padding error");
+            e.printStackTrace();
+            return "";
+        }
+        return Base64.getEncoder().encodeToString(encrypted);
+    }
+
+    /**
+     * 随机产生 length 个字符并拼接成串
+     * @param len 长度 len
+     * @return 随机字符组成的字符串
+     */
+    private static String randomString(int len) {
+        StringBuilder builder = new StringBuilder();
+        Random random = new Random();
+        for (int i = 0; i < len; i++) {
+            builder.append(PADDING_CHARS.charAt(random.nextInt(PADDING_CHARS.length() - 1)));
+        }
+        return builder.toString();
+    }
+
+    /**
+     * 将密码补充成符合 AES-128 CBC 规范形式
+     * @param password 明文密码
+     * @return 补充后的密码
+     */
+    private static String getPaddingPassword(String password) {
+        return randomString(64) + password;
+    }
+}

--- a/src/test/java/com/yilin/csuftspider/utils/TestPasswordUtil.java
+++ b/src/test/java/com/yilin/csuftspider/utils/TestPasswordUtil.java
@@ -1,0 +1,82 @@
+package com.yilin.csuftspider.utils;
+
+
+import org.apache.http.*;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.jupiter.api.Test;
+import java.util.*;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <p>
+ * 测试 PasswordUtil 工具类
+ * </p>
+ *
+ * @author : Xbai-hang
+ * @since : 2022/10/11
+ */
+public class TestPasswordUtil {
+
+    /**
+     * 测试工具类
+     */
+    @Test
+    public void test() {
+        System.out.println(PasswordUtil.encrypt("666666", "SIKj33ZupTY3qqIG"));
+    }
+
+    /**
+     * 测试教务处爬虫
+     */
+    @Test
+    public void testLogin() throws IOException {
+        CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+        // HttpClient httpClient = HttpClients.createDefault();
+        HttpGet httpGet = new HttpGet("http://authserver.csuft.edu.cn/authserver/login?service=http%3A%2F%2Fjwgl.csuft.edu.cn%2F");
+        httpGet.setHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36");
+        HttpResponse response = httpClient.execute(httpGet);
+        Document document = Jsoup.parse(EntityUtils.toString(response.getEntity()));
+        Elements inputs = document.select("input[type=hidden]");
+        Map<String, String> mm = new HashMap<>();
+        for (Element input : inputs) {
+            mm.put(input.attr("name"), input.attr("value"));
+        }
+        System.out.println("==== lt: " + mm.get("lt"));
+        // System.out.println(document.getElementsByTag("script").get(1).hasText()); // false 获取 script 标签中的内容需要使用 data
+        String salt = document.getElementsByTag("script")
+                .get(1).html().split("=")[2].trim().substring(1, 17);
+        List<NameValuePair> nvps = new ArrayList<>();
+        nvps.add(new BasicNameValuePair("username", "敏感数据脱敏"));
+        nvps.add(new BasicNameValuePair("password", PasswordUtil.encrypt("敏感数据脱敏", salt)));
+        nvps.add(new BasicNameValuePair("lt", mm.get("lt")));
+        nvps.add(new BasicNameValuePair("dllt", mm.get("dllt")));
+        nvps.add(new BasicNameValuePair("execution", mm.get("execution")));
+        nvps.add(new BasicNameValuePair("_eventId", mm.get("_eventId")));
+        nvps.add(new BasicNameValuePair("rmShown", mm.get("rmShown")));
+        HttpPost httpPost = new HttpPost("http://authserver.csuft.edu.cn/authserver/login?service=http%3A%2F%2Fjwgl.csuft.edu.cn%2F");
+        httpPost.setEntity(new UrlEncodedFormEntity(nvps, Consts.UTF_8));
+
+        response = httpClient.execute(httpPost);
+        // 三次重定向 均是 get 请求
+        while (response.getStatusLine().getStatusCode() == 302) {
+            Header header = response.getFirstHeader("location");
+            String newUri = header.getValue();
+            httpGet = new HttpGet(newUri);
+            httpGet.setHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36");
+            response = httpClient.execute(httpGet);
+        }
+        System.out.println(EntityUtils.toString(response.getEntity()));
+    }
+}

--- a/src/test/java/com/yilin/csuftspider/utils/TestPasswordUtil.java
+++ b/src/test/java/com/yilin/csuftspider/utils/TestPasswordUtil.java
@@ -1,6 +1,11 @@
 package com.yilin.csuftspider.utils;
 
 
+import com.alibaba.fastjson2.JSONObject;
+import com.yilin.csuftspider.common.ErrorCode;
+import com.yilin.csuftspider.exception.BusinessException;
+import net.sourceforge.tess4j.Tesseract;
+import net.sourceforge.tess4j.TesseractException;
 import org.apache.http.*;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
@@ -9,11 +14,18 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
+import org.json.JSONException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.io.IOException;
 import java.util.HashMap;
@@ -29,19 +41,55 @@ import java.util.Map;
  */
 public class TestPasswordUtil {
 
+    private static final Tesseract tesseract = new Tesseract();
+
+    static {
+        // 英文资源包
+        tesseract.setLanguage("eng");
+
+        Path dataDirectory = Paths.get(System.getProperty("user.dir") + "/tessdata");
+
+        tesseract.setDatapath(dataDirectory.toString());
+
+        tesseract.setOcrEngineMode(7);
+    }
+
+    /**
+     * 教务处账号
+     */
+    private static final String USERNAME = "敏感数据脱敏";
+
+    /**
+     * 教务处密码
+     */
+    private static final String PASSWORD = "敏感数据脱敏";
+
+    /**
+     * 打码平台 KEY
+     *   https://www.345api.com/ 0.01 元/次，免费 50 次
+     */
+    private static final String CODE_KEY = "敏感数据脱敏";
+
+    private static final Set<Character> dirtySet = new HashSet<Character>(128) {{
+        add('A'); add('B'); add('C'); add('D'); add('E'); add('F'); add('G'); add('H'); add('I'); add('J'); add('K'); add('L');
+        add('M'); add('N'); add('O'); add('P'); add('Q'); add('R'); add('S'); add('T'); add('U'); add('V'); add('W'); add('X');
+        add('Y'); add('Z'); add('0'); add('1'); add('2'); add('3'); add('4'); add('5'); add('6'); add('7'); add('8'); add('9');
+    }};
+
+
     /**
      * 测试工具类
      */
     @Test
     public void test() {
-        System.out.println(PasswordUtil.encrypt("666666", "SIKj33ZupTY3qqIG"));
+        System.out.println(PasswordUtil.encrypt(USERNAME, "SIKj33ZupTY3qqIG"));
     }
 
     /**
      * 测试教务处爬虫
      */
     @Test
-    public void testLogin() throws IOException {
+    public void testLogin() throws IOException, TesseractException {
         CloseableHttpClient httpClient = HttpClientBuilder.create().build();
         // HttpClient httpClient = HttpClients.createDefault();
         HttpGet httpGet = new HttpGet("http://authserver.csuft.edu.cn/authserver/login?service=http%3A%2F%2Fjwgl.csuft.edu.cn%2F");
@@ -58,13 +106,60 @@ public class TestPasswordUtil {
         String salt = document.getElementsByTag("script")
                 .get(1).html().split("=")[2].trim().substring(1, 17);
         List<NameValuePair> nvps = new ArrayList<>();
-        nvps.add(new BasicNameValuePair("username", "敏感数据脱敏"));
-        nvps.add(new BasicNameValuePair("password", PasswordUtil.encrypt("敏感数据脱敏", salt)));
+        nvps.add(new BasicNameValuePair("username", USERNAME));
+        nvps.add(new BasicNameValuePair("password", PasswordUtil.encrypt(PASSWORD, salt)));
         nvps.add(new BasicNameValuePair("lt", mm.get("lt")));
         nvps.add(new BasicNameValuePair("dllt", mm.get("dllt")));
         nvps.add(new BasicNameValuePair("execution", mm.get("execution")));
         nvps.add(new BasicNameValuePair("_eventId", mm.get("_eventId")));
         nvps.add(new BasicNameValuePair("rmShown", mm.get("rmShown")));
+        // 加入验证码判断的逻辑
+        httpGet = new HttpGet("http://authserver.csuft.edu.cn/authserver/needCaptcha.html?" +
+                "username=" + USERNAME +
+                "&pwdEncrypt2=pwdEncryptSalt" + "&_=" + System.currentTimeMillis());
+        httpGet.setHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36");
+        response = httpClient.execute(httpGet);
+        // 返回值中是 true or false 代表是否需要验证码
+        boolean useCaptcha = EntityUtils.toString(response.getEntity()).equals("true");
+        if (useCaptcha) {
+            System.out.println("需要使用验证码");
+            // 获取验证码
+            httpGet = new HttpGet("http://authserver.csuft.edu.cn/authserver/captcha.html?ts=" + System.currentTimeMillis() % 1000);
+            httpGet.setHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36");
+            response = httpClient.execute(httpGet);
+            // 4kb 足够了，下载了 50 张验证码发现大小均在 2200 ~ 2300 字节左右，也可以根据 Entity 的 ContentLength 来动态创建
+            byte[] bytes = new byte[1024 * 4];
+            int read = response.getEntity().getContent().read(bytes);
+            if  (read == -1) { // 获取图片失败
+               return;
+            }
+            // 保存至本地
+            // FileOutputStream fos = new FileOutputStream(new File("D:/a.jpg"));
+            // fos.write(bytes);
+
+            // 效果较差
+            // BufferedImage image = ImageIO.read(response.getEntity().getContent());
+            //
+            // String result = tesseract.doOCR(image);
+            // System.out.println(result);
+            // System.out.println(removeDirtyData(result));
+
+            HttpPost httpPost = new HttpPost("https://www.345api.com/api/code/ocr?key=" + CODE_KEY + "&data=" +
+                    "data:image/png;base64," + Base64.getEncoder().encodeToString(bytes));
+            response = httpClient.execute(httpPost);
+            // {"code":200,"msg":"识别成功","data":{"code_data":"nk2e","require_date":0.18,"used":2,"remaining":-2},"debug":"","source":"https://www.345api.com/ 345API数据接口","exec_time":0.380164,"user_ip":"183.214.91.2"}
+            String json = EntityUtils.toString(response.getEntity());
+            System.out.println(json);
+            JSONObject data = JSONObject.parseObject(json).getJSONObject("data");
+            if (data == null) {
+                System.out.println("打码平台接口异常");
+                throw new BusinessException(ErrorCode.SYSTEM_ERROR);
+            }
+            nvps.add(new BasicNameValuePair("captchaResponse", data.getString("code_data")));
+            System.out.println(nvps);
+        }
+
+
         HttpPost httpPost = new HttpPost("http://authserver.csuft.edu.cn/authserver/login?service=http%3A%2F%2Fjwgl.csuft.edu.cn%2F");
         httpPost.setEntity(new UrlEncodedFormEntity(nvps, Consts.UTF_8));
 
@@ -77,6 +172,74 @@ public class TestPasswordUtil {
             httpGet.setHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36");
             response = httpClient.execute(httpGet);
         }
-        System.out.println(EntityUtils.toString(response.getEntity()));
+        String res = EntityUtils.toString(response.getEntity());
+        Header location = response.getFirstHeader("location");
+        // 登陆成功的时候有时会重定向到 http://authserver.csuft.edu.cn/authserver/index.do 页面，响应头也含有 location，但是是已经登陆成功的情况
+        if (location != null && location.getValue().contains("authserver/login")) {
+            String errorMsg = Jsoup.parse(res).getElementById("msg").text();
+            throw new BusinessException(ErrorCode.SYSTEM_ERROR, errorMsg);
+        }
+        System.out.println(location);
+        System.out.println(res);
+    }
+
+    /**
+     * 测试时间戳（毫秒级）1665510840534
+     */
+    @Test
+    public void testMillsTimestamp() {
+        System.out.println(System.currentTimeMillis());
+
+        System.out.println(System.currentTimeMillis() % 1000);
+    }
+
+    /**
+     * 测试验证码识别
+     */
+    @Test
+    public void testCaptcha() throws IOException, TesseractException {
+        Tesseract tesseract = new Tesseract();
+        // 英文资源包
+        tesseract.setLanguage("eng");
+
+        Path dataDirectory = Paths.get(System.getProperty("user.dir") + "/tessdata");
+
+        tesseract.setDatapath(dataDirectory.toString());
+
+        tesseract.setOcrEngineMode(1);
+
+        BufferedImage image = ImageIO.read(new FileInputStream("D://a.jpg"));
+
+        String result = tesseract.doOCR(image);
+
+        System.out.println(removeDirtyData(result));
+    }
+
+    /**
+     * 去除脏数据
+     * @param dirtyData OCR 识别后的 脏数据
+     * @return 验证码
+     */
+    private String removeDirtyData(String dirtyData) {
+        char[] chars = dirtyData.toUpperCase().toCharArray();
+        StringBuilder builder = new StringBuilder();
+        for (char ch : chars) {
+            if (builder.length() == 4) {
+                break;
+            }
+            if (!dirtySet.contains(ch)) {
+                continue;
+            }
+            builder.append(ch);
+        }
+        return builder.toString();
+    }
+
+    @Test
+    public void testJsonObjectConvert() throws JSONException {
+        String message = "{\"code\":200,\"msg\":\"识别成功\",\"data\":{\"code_data\":\"nk2e\",\"require_date\":0.18,\"used\":2,\"remaining\":-2},\"debug\":\"\",\"source\":\"https://www.345api.com/ 345API数据接口\",\"exec_time\":0.380164,\"user_ip\":\"183.214.91.2\"}";
+        // Captcha parse = JSON.parseObject(message.getBytes(StandardCharsets.UTF_8), Captcha.class);
+        JSONObject captcha = JSONObject.parseObject(message);
+        System.out.println(captcha.getJSONObject("data").getString("code_data"));
     }
 }


### PR DESCRIPTION
> **commit 5349608：**

Java 中调用 JS 应该没有原生实现快（我猜的），增加了密码加密工具类。

> **commit 7425431：**

- [x] 实现了验证码相关的逻辑，用户触发验证码的情况如下：
    1. 连续三次输入了错误的账号或密码
    2. ······
- [x] 通过调用对应的接口（参数为学号 username）来向服务端询问是否需要使用验证码。
- [x] 通过调用验证码接口获取验证码字节流，并传给对应的打码平台
- [x] 将验证码字段加入请求体并登录 

> **待实现：**
- [ ] 通过爬虫批量爬取验证码图片，然后训练 Tess4j 的模型以提高识别率（目前低到离谱）
- [ ] ···